### PR TITLE
Fix HTML lang attribute

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="%lang%">
   <head>
     <meta charset="utf-8" />
     %sveltekit.head%

--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -1,0 +1,14 @@
+import { supportedLocales } from '$lib/services/i18n.js';
+
+// Set the `lang` attribute on `<html>`
+// https://github.com/sveltejs/kit/issues/3091
+export function handle({ event, resolve }) {
+  const { pathname } = event.url;
+
+  const [, lang = 'en'] =
+    pathname.match(new RegExp(`^\\/(${Object.keys(supportedLocales).join('|')})\\b`)) || [];
+
+  return resolve(event, {
+    transformPageChunk: ({ html }) => html.replace('%lang%', lang),
+  });
+}


### PR DESCRIPTION
HTML 上で指定されている記述言語が日本語ページ (ja) でも英語 (en) のままになっている問題を修正します。